### PR TITLE
fix: fix images loading bug when tap multiple times

### DIFF
--- a/ImagesApp.xcodeproj/project.pbxproj
+++ b/ImagesApp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		341CA61D2C81B2D1007E8BC6 /* TypeAlias.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341CA61C2C81B2D1007E8BC6 /* TypeAlias.swift */; };
 		341CA61F2C81C041007E8BC6 /* ImageCacher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341CA61E2C81C041007E8BC6 /* ImageCacher.swift */; };
 		341CA6212C81C197007E8BC6 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341CA6202C81C197007E8BC6 /* ImageService.swift */; };
+		34E62CDF2C897C8200C0BEF8 /* UIBarButtonItem+Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E62CDE2C897C8200C0BEF8 /* UIBarButtonItem+Debounce.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +43,7 @@
 		341CA61C2C81B2D1007E8BC6 /* TypeAlias.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeAlias.swift; sourceTree = "<group>"; };
 		341CA61E2C81C041007E8BC6 /* ImageCacher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacher.swift; sourceTree = "<group>"; };
 		341CA6202C81C197007E8BC6 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
+		34E62CDE2C897C8200C0BEF8 /* UIBarButtonItem+Debounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Debounce.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -126,6 +128,7 @@
 				341CA6182C81B193007E8BC6 /* CacheHelper.swift */,
 				341CA61A2C81B1A9007E8BC6 /* CacheProperties.swift */,
 				341CA61C2C81B2D1007E8BC6 /* TypeAlias.swift */,
+				34E62CDE2C897C8200C0BEF8 /* UIBarButtonItem+Debounce.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -224,6 +227,7 @@
 				341CA60D2C81ADD6007E8BC6 /* ViewModel.swift in Sources */,
 				341CA5F92C81A7A1007E8BC6 /* ViewController.swift in Sources */,
 				341CA60B2C81AB11007E8BC6 /* ImageCell.swift in Sources */,
+				34E62CDF2C897C8200C0BEF8 /* UIBarButtonItem+Debounce.swift in Sources */,
 				341CA5F52C81A7A1007E8BC6 /* AppDelegate.swift in Sources */,
 				341CA6192C81B193007E8BC6 /* CacheHelper.swift in Sources */,
 				341CA61F2C81C041007E8BC6 /* ImageCacher.swift in Sources */,

--- a/ImagesApp/Sources/Helper/UIBarButtonItem+Debounce.swift
+++ b/ImagesApp/Sources/Helper/UIBarButtonItem+Debounce.swift
@@ -1,0 +1,21 @@
+//
+//  UIControl+Debounce.swift
+//  ImagesApp
+//
+//  Created by don.vo on 9/5/24.
+//
+
+import UIKit
+
+extension UIBarButtonItem {
+    func debounce(delay seconds: Double = 1) {
+        guard let view = self.value(forKey: "view") as? UIView else {
+            return
+        }
+
+        view.isUserInteractionEnabled = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
+            view.isUserInteractionEnabled = true
+        }
+    }
+}

--- a/ImagesApp/Sources/View/ViewController.swift
+++ b/ImagesApp/Sources/View/ViewController.swift
@@ -13,6 +13,16 @@ class ViewController: UIViewController {
 
     private lazy var viewModel: ViewModelProtocol = ViewModel()
 
+    private lazy var reloadButton: UIBarButtonItem = {
+        let reloadButton = UIBarButtonItem(
+            title: "Reload",
+            style: .plain,
+            target: self,
+            action: #selector(self.reloadAllImages)
+        )
+        return reloadButton
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = "images"
@@ -40,21 +50,19 @@ class ViewController: UIViewController {
             target: self,
             action: #selector(addNewImages)
         )
-        let reloadButton = UIBarButtonItem(
-            title: "Reload",
-            style: .plain,
-            target: self,
-            action: #selector(reloadAllImages)
-        )
         navigationItem.rightBarButtonItems = [addButton, reloadButton]
     }
 
     @objc func addNewImages() {
         viewModel.addImage()
-        collectionView.reloadData()
+        collectionView.performBatchUpdates({
+            let indexPath = IndexPath(item: viewModel.imageCount - 1, section: 0)
+            collectionView.insertItems(at: [indexPath])
+        }, completion: nil)
     }
 
     @objc func reloadAllImages() {
+        reloadButton.debounce()
         viewModel.reloadImages()
         collectionView.reloadData()
     }


### PR DESCRIPTION
### Problem
- When adding new Image, use `CollectionView.reloadData()` make all the data reloaded -> Lead to unexpected behavior of reusable Cell.
- Tap reload multiple time make data reloaded accordingly.

### Key Changes
- Fix image loading issue when tapped '+'  multiple time by using `CollectionView.insertItems()`
- Add debouncer to Reload button to prevent tapping multiple time

### Screen shot
![Simulator Screen Recording - iPhone 15 Pro - 2024-09-05 at 13 21 57](https://github.com/user-attachments/assets/ce4e2645-9531-4bb2-8917-d0d383fa5f31)
